### PR TITLE
Artwork dialog fixes

### DIFF
--- a/language/resource.language.cs_cz/strings.po
+++ b/language/resource.language.cs_cz/strings.po
@@ -145,7 +145,7 @@ msgid "All TV Shows"
 msgstr "Všechny seriály"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Stahování artwork"
 
 msgctxt "#31053"

--- a/language/resource.language.da_dk/strings.po
+++ b/language/resource.language.da_dk/strings.po
@@ -33,8 +33,8 @@ msgid "All TV Shows"
 msgstr "Alle TV-serier"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Artwork Downloader"
+msgid "Artwork Beef"
+msgstr "Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"

--- a/language/resource.language.de_de/strings.po
+++ b/language/resource.language.de_de/strings.po
@@ -197,8 +197,8 @@ msgid "All TV Shows"
 msgstr "Alle Fernsehserien"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Programm zum Herunterladen von Illustrationen"
+msgid "Artwork Beef"
+msgstr "Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"
@@ -2791,6 +2791,14 @@ msgstr "Textfarbe im EPG-Guide (kein Fokus)"
 msgctxt "#31780"
 msgid "PVR Guide focused item textcolor"
 msgstr "Textfarbe im EPG-Guide (Fokus)"
+
+msgctxt "#31827"
+msgid "Internal Artwork Dialog"
+msgstr "Interner Artwork Dialog"
+
+msgctxt "#31828"
+msgid "External Artwork Dialog"
+msgstr "Externer Artwork Dialog"
 
 
 # malvinas2

--- a/language/resource.language.el_gr/strings.po
+++ b/language/resource.language.el_gr/strings.po
@@ -85,8 +85,8 @@ msgid "All TV Shows"
 msgstr "Όλες οι Τηλ. Σειρές"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Artwork Downloader"
+msgid "Artwork Beef"
+msgstr "Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"

--- a/language/resource.language.en_au/strings.po
+++ b/language/resource.language.en_au/strings.po
@@ -45,8 +45,8 @@ msgid "All TV Shows"
 msgstr "All TV Shows"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Artwork Downloader"
+msgid "Artwork Beef"
+msgstr "Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -203,7 +203,7 @@ msgid "All TV Shows"
 msgstr ""
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr ""
 
 msgctxt "#31053"
@@ -390,9 +390,7 @@ msgctxt "#31098"
 msgid "BannerPlex"
 msgstr ""
 
-msgctxt "#31099"
-msgid "Enable automatic download during library scan (artwork downloader addon)"
-msgstr ""
+# empty string with id 31099
 
 msgctxt "#31100"
 msgid "==unused position=="
@@ -2986,6 +2984,13 @@ msgctxt "#31826"
 msgid "Select country flags / icons"
 msgstr ""
 
+msgctxt "#31827"
+msgid "Internal Artwork Dialog"
+msgstr ""
+
+msgctxt "#31828"
+msgid "External Artwork Dialog"
+msgstr ""
 
 # malvinas2
 

--- a/language/resource.language.en_nz/strings.po
+++ b/language/resource.language.en_nz/strings.po
@@ -197,8 +197,8 @@ msgid "All TV Shows"
 msgstr "All TV Shows"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Artwork Downloader"
+msgid "Artwork Beef"
+msgstr "Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"
@@ -384,9 +384,7 @@ msgctxt "#31098"
 msgid "BannerPlex"
 msgstr "BannerPlex"
 
-msgctxt "#31099"
-msgid "Enable automatic download during library scan (artwork downloader addon)"
-msgstr "Enable automatic download during library scan (artwork downloader addon)"
+# empty string with id 31099
 
 msgctxt "#31100"
 msgid "==unused position=="

--- a/language/resource.language.en_us/strings.po
+++ b/language/resource.language.en_us/strings.po
@@ -197,8 +197,8 @@ msgid "All TV Shows"
 msgstr "All TV Shows"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Artwork Downloader"
+msgid "Artwork Beef"
+msgstr "Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"
@@ -384,9 +384,7 @@ msgctxt "#31098"
 msgid "BannerPlex"
 msgstr "BannerPlex"
 
-msgctxt "#31099"
-msgid "Enable automatic download during library scan (artwork downloader addon)"
-msgstr "Enable automatic download during library scan (artwork downloader addon)"
+# empty string with id 31099
 
 msgctxt "#31100"
 msgid "==unused position=="
@@ -2963,3 +2961,11 @@ msgstr "Don't use rich artwork on the OSD at livetv playback"
 msgctxt "#31826"
 msgid "Select country flags / icons"
 msgstr "Select country flags / icons"
+
+msgctxt "#31827"
+msgid "Internal Artwork Dialog"
+msgstr "Internal Artwork Dialog"
+
+msgctxt "#31828"
+msgid "External Artwork Dialog"
+msgstr "External Artwork Dialog"

--- a/language/resource.language.es_es/strings.po
+++ b/language/resource.language.es_es/strings.po
@@ -197,7 +197,7 @@ msgid "All TV Shows"
 msgstr "Todas las Series"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Descargar Artwork"
 
 msgctxt "#31053"
@@ -384,9 +384,7 @@ msgctxt "#31098"
 msgid "BannerPlex"
 msgstr "BannerPlex"
 
-msgctxt "#31099"
-msgid "Enable automatic download during library scan (artwork downloader addon)"
-msgstr "Activar descarga automática durante la exploración de la colección (complemento artwok downloader)"
+# empty string with id 31099
 
 msgctxt "#31100"
 msgid "==unused position=="

--- a/language/resource.language.eu_es/strings.po
+++ b/language/resource.language.eu_es/strings.po
@@ -21,8 +21,8 @@ msgid "Trailers"
 msgstr "Trailerra"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Artwork Downloader"
+msgid "Artwork Beef"
+msgstr "Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"

--- a/language/resource.language.fi_fi/strings.po
+++ b/language/resource.language.fi_fi/strings.po
@@ -197,8 +197,8 @@ msgid "All TV Shows"
 msgstr "Kaikki tv-sarjat"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Artwork Downloader"
+msgid "Artwork Beef"
+msgstr "Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"
@@ -384,9 +384,7 @@ msgctxt "#31098"
 msgid "BannerPlex"
 msgstr "BanneriPlex"
 
-msgctxt "#31099"
-msgid "Enable automatic download during library scan (artwork downloader addon)"
-msgstr "Lataa automaattisesti kirjaston päivityksen yhteydessä (artwork downloader -lisäosa)"
+# empty string with id 31099
 
 msgctxt "#31100"
 msgid "==unused position=="

--- a/language/resource.language.fr_ca/strings.po
+++ b/language/resource.language.fr_ca/strings.po
@@ -193,7 +193,7 @@ msgid "All TV Shows"
 msgstr "Toutes les émissions télé"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Téléchargeur d’illustrations"
 
 msgctxt "#31053"

--- a/language/resource.language.fr_fr/strings.po
+++ b/language/resource.language.fr_fr/strings.po
@@ -197,7 +197,7 @@ msgid "All TV Shows"
 msgstr "Toutes les séries TV"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Téléchargeur d'illustration"
 
 msgctxt "#31053"

--- a/language/resource.language.gl_es/strings.po
+++ b/language/resource.language.gl_es/strings.po
@@ -45,7 +45,7 @@ msgid "All TV Shows"
 msgstr "Todas as Series de TV"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Descargador de Ilustracións"
 
 msgctxt "#31053"

--- a/language/resource.language.he_il/strings.po
+++ b/language/resource.language.he_il/strings.po
@@ -197,7 +197,7 @@ msgid "All TV Shows"
 msgstr "כל הסדרות"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "סקריפט הורדת גרפיקה"
 
 msgctxt "#31053"
@@ -384,9 +384,7 @@ msgctxt "#31098"
 msgid "BannerPlex"
 msgstr "כרזת פלקס"
 
-msgctxt "#31099"
-msgid "Enable automatic download during library scan (artwork downloader addon)"
-msgstr "אפשר הורדה אוטומטית במהלך סריקת ספרייה (הרחבת artwork downloader)"
+# empty string with id 31099
 
 msgctxt "#31100"
 msgid "==unused position=="

--- a/language/resource.language.hr_hr/strings.po
+++ b/language/resource.language.hr_hr/strings.po
@@ -197,7 +197,7 @@ msgid "All TV Shows"
 msgstr "Sve TV serije"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Preuzimatelj slika omota"
 
 msgctxt "#31053"

--- a/language/resource.language.hu_hu/strings.po
+++ b/language/resource.language.hu_hu/strings.po
@@ -189,8 +189,8 @@ msgid "All TV Shows"
 msgstr "Összes sorozat"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Artwork Downloader"
+msgid "Artwork Beef"
+msgstr "Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"
@@ -348,9 +348,7 @@ msgctxt "#31098"
 msgid "BannerPlex"
 msgstr "BannerPlex"
 
-msgctxt "#31099"
-msgid "Enable automatic download during library scan (artwork downloader addon)"
-msgstr "Automatikus letöltés engedélyezése könyvtár átvizsgálása közben (artwork downloader kiegészítő))"
+# empty string with id 31099
 
 msgctxt "#31100"
 msgid "==unused position=="

--- a/language/resource.language.it_it/strings.po
+++ b/language/resource.language.it_it/strings.po
@@ -197,8 +197,8 @@ msgid "All TV Shows"
 msgstr "Tutte le Serie TV"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Artwork Downloader"
+msgid "Artwork Beef"
+msgstr "Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"
@@ -384,9 +384,7 @@ msgctxt "#31098"
 msgid "BannerPlex"
 msgstr "BannerPlex"
 
-msgctxt "#31099"
-msgid "Enable automatic download during library scan (artwork downloader addon)"
-msgstr "Abilita download automatico durante scansione Libreria (Add-On Artwork Downloader)"
+# empty string with id 31099
 
 msgctxt "#31100"
 msgid "==unused position=="

--- a/language/resource.language.ja_jp/strings.po
+++ b/language/resource.language.ja_jp/strings.po
@@ -149,7 +149,7 @@ msgid "All TV Shows"
 msgstr "全てのテレビ番組"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "アートワークダウンローダ"
 
 msgctxt "#31053"

--- a/language/resource.language.ko_kr/strings.po
+++ b/language/resource.language.ko_kr/strings.po
@@ -45,8 +45,8 @@ msgid "All TV Shows"
 msgstr "모든 TV 쇼"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Artwork Downloader 애드온"
+msgid "Artwork Beef"
+msgstr "Artwork Beef 애드온"
 
 msgctxt "#31053"
 msgid "Poster"

--- a/language/resource.language.lt_lt/strings.po
+++ b/language/resource.language.lt_lt/strings.po
@@ -197,8 +197,8 @@ msgid "All TV Shows"
 msgstr "Visos TV laidos"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Artwork Downloader"
+msgid "Artwork Beef"
+msgstr "Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"
@@ -384,9 +384,7 @@ msgctxt "#31098"
 msgid "BannerPlex"
 msgstr "BannerPlex"
 
-msgctxt "#31099"
-msgid "Enable automatic download during library scan (artwork downloader addon)"
-msgstr "Įjungti automatinį atsiuntimą bibliotekos nuskaitymo metu (Artwork Downloader priedas)"
+# empty string with id 31099
 
 msgctxt "#31100"
 msgid "==unused position=="

--- a/language/resource.language.ms_my/strings.po
+++ b/language/resource.language.ms_my/strings.po
@@ -197,7 +197,7 @@ msgid "All TV Shows"
 msgstr "Semua Rancangan TV"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Pemuat Turun Kerja Seni"
 
 msgctxt "#31053"
@@ -384,9 +384,7 @@ msgctxt "#31098"
 msgid "BannerPlex"
 msgstr "BannerPlex"
 
-msgctxt "#31099"
-msgid "Enable automatic download during library scan (artwork downloader addon)"
-msgstr "Benarkan muat turun berautomatik ketika imbas pustaka (tambahan pemuat turun kerja seni)"
+# empty string with id 31099
 
 msgctxt "#31100"
 msgid "==unused position=="

--- a/language/resource.language.nb_no/strings.po
+++ b/language/resource.language.nb_no/strings.po
@@ -73,7 +73,7 @@ msgid "All TV Shows"
 msgstr "Alle TV-programmer"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Artwork Nedlaster"
 
 msgctxt "#31053"

--- a/language/resource.language.nl_nl/strings.po
+++ b/language/resource.language.nl_nl/strings.po
@@ -197,7 +197,7 @@ msgid "All TV Shows"
 msgstr "Alle TV series"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Illustatie Downloader"
 
 msgctxt "#31053"
@@ -384,9 +384,7 @@ msgctxt "#31098"
 msgid "BannerPlex"
 msgstr "BannerPlex"
 
-msgctxt "#31099"
-msgid "Enable automatic download during library scan (artwork downloader addon)"
-msgstr "Activeer automatische download gedurende bibliotheek scan (illustatie downloader add-on)"
+# empty string with id 31099
 
 msgctxt "#31100"
 msgid "==unused position=="

--- a/language/resource.language.pl_pl/strings.po
+++ b/language/resource.language.pl_pl/strings.po
@@ -197,8 +197,8 @@ msgid "All TV Shows"
 msgstr "Wszystkie"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Dodatek Artwork Downloader"
+msgid "Artwork Beef"
+msgstr "Dodatek Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"
@@ -380,9 +380,7 @@ msgctxt "#31098"
 msgid "BannerPlex"
 msgstr "BannerPlex"
 
-msgctxt "#31099"
-msgid "Enable automatic download during library scan (artwork downloader addon)"
-msgstr "Pobieraj automatycznie podczas skanowania biblioteki (dodatek Artwork Downloader)"
+# empty string with id 31099
 
 msgctxt "#31100"
 msgid "==unused position=="

--- a/language/resource.language.pt_br/strings.po
+++ b/language/resource.language.pt_br/strings.po
@@ -185,8 +185,8 @@ msgid "All TV Shows"
 msgstr "Todos as Séries de TV"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Artwork Downloader"
+msgid "Artwork Beef"
+msgstr "Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"

--- a/language/resource.language.pt_pt/strings.po
+++ b/language/resource.language.pt_pt/strings.po
@@ -189,8 +189,8 @@ msgid "All TV Shows"
 msgstr "Todas as séries de TV "
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Artwork Downloader"
+msgid "Artwork Beef"
+msgstr "Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"

--- a/language/resource.language.ru_ru/strings.po
+++ b/language/resource.language.ru_ru/strings.po
@@ -193,7 +193,7 @@ msgid "All TV Shows"
 msgstr "Все ТВ Шоу"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Загрузчик Иллюстраций"
 
 msgctxt "#31053"

--- a/language/resource.language.sk_sk/strings.po
+++ b/language/resource.language.sk_sk/strings.po
@@ -57,7 +57,7 @@ msgid "All TV Shows"
 msgstr "Všetky seriály"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Preberanie Artwork"
 
 msgctxt "#31053"

--- a/language/resource.language.sr_rs/strings.po
+++ b/language/resource.language.sr_rs/strings.po
@@ -197,7 +197,7 @@ msgid "All TV Shows"
 msgstr "Све ТВ Серије"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Преузимач Илустрација"
 
 msgctxt "#31053"

--- a/language/resource.language.sr_rs@latin/strings.po
+++ b/language/resource.language.sr_rs@latin/strings.po
@@ -197,7 +197,7 @@ msgid "All TV Shows"
 msgstr "Sve TV Serije"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Preuzimač Ilustracija"
 
 msgctxt "#31053"

--- a/language/resource.language.sv_se/strings.po
+++ b/language/resource.language.sv_se/strings.po
@@ -137,7 +137,7 @@ msgid "All TV Shows"
 msgstr "Alla TV-serier"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Omslagsnedladdare"
 
 msgctxt "#31053"

--- a/language/resource.language.szl/strings.po
+++ b/language/resource.language.szl/strings.po
@@ -17,8 +17,8 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
-msgstr "Przidŏwek Artwork Downloader"
+msgid "Artwork Beef"
+msgstr "Przidŏwek Artwork Beef"
 
 msgctxt "#31053"
 msgid "Poster"

--- a/language/resource.language.th_th/strings.po
+++ b/language/resource.language.th_th/strings.po
@@ -25,7 +25,7 @@ msgid "Latest Movies"
 msgstr "ภาพยนตร์ ล่าสุด"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "ตัวดึงข้อมูล งานศิลป์"
 
 msgctxt "#31053"

--- a/language/resource.language.tr_tr/strings.po
+++ b/language/resource.language.tr_tr/strings.po
@@ -197,7 +197,7 @@ msgid "All TV Shows"
 msgstr "Bütün TV Programları"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "Çizim İndirici"
 
 msgctxt "#31053"

--- a/language/resource.language.zh_cn/strings.po
+++ b/language/resource.language.zh_cn/strings.po
@@ -185,7 +185,7 @@ msgid "All TV Shows"
 msgstr "所有剧集"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "艺术图片下载器"
 
 msgctxt "#31053"

--- a/language/resource.language.zh_tw/strings.po
+++ b/language/resource.language.zh_tw/strings.po
@@ -33,7 +33,7 @@ msgid "Latest Movies"
 msgstr "最新電影"
 
 msgctxt "#31052"
-msgid "Artwork Downloader"
+msgid "Artwork Beef"
 msgstr "美術圖下載器"
 
 msgctxt "#31053"

--- a/xml/Custom_MediaDialog.xml
+++ b/xml/Custom_MediaDialog.xml
@@ -55,26 +55,27 @@
                 <posy>300</posy>
                 <width>644</width>
                 <height>60</height>
-                <label>$LOCALIZE[13511]</label>
+                <label>$LOCALIZE[31827]</label>
                 <align>left</align>
                 <textoffsetx>20</textoffsetx>
                 <include>DialogButton</include>
                 <texturefocus colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">colors/color_white.png</texturefocus>
                 <texturenofocus>dialogs/default/separator.png</texturenofocus>
-                <onclick>SendClick(2003,10)</onclick>
+                <onclick condition="Window.IsActive(DialogVideoInfo.xml)">SendClick(12003,10)</onclick>
+                <onclick condition="Window.IsActive(DialogMusicInfo.xml)">SendClick(12001,10)</onclick>
                 <onup>3</onup>
                 <ondown>3</ondown>
                 <onleft>7</onleft>
                 <onright>7</onright>
                 <visible>Window.IsActive(DialogVideoInfo.xml | Window.IsActive(DialogMusicInfo.xml)</visible>
             </control>
-            <!--Label Artwork beef-->
+            <!--Label External Artwork-->
             <control type="button">
                 <posx>638</posx>
                 <posy>368</posy>
                 <width>644</width>
                 <height>53</height>
-                <label>[B]$LOCALIZE[31052][/B]</label>
+                <label>[B]$LOCALIZE[31828][/B]</label>
                 <align>left</align>
                 <textoffsetx>20</textoffsetx>
                 <include>DialogButton</include>
@@ -155,7 +156,7 @@
                 </focusedlayout>
                 <content>
                     <item id="1">
-                        <!--Get poster-->
+                        <!--Get artwork-->
                         <label>31052</label>
                         <onclick condition="Container.Content(movies)">RunScript(script.artwork.beef,mode=gui,mediatype=movie,dbid=$INFO[ListItem.DBID])</onclick>
                         <onclick condition="Container.Content(tvshows)">RunScript(script.artwork.beef,mode=gui,mediatype=tvshow,dbid=$INFO[ListItem.DBID])</onclick>
@@ -163,6 +164,7 @@
                         <onclick condition="Container.Content(artists)">RunScript(script.artwork.beef,mode=gui,mediatype=artist,dbid=$INFO[ListItem.DBID])</onclick>
                         <onclick condition="Container.Content(albums)">RunScript(script.artwork.beef,mode=gui,mediatype=album,dbid=$INFO[ListItem.DBID])</onclick>
                         <onclick condition="Container.Content(songs)">RunScript(script.artwork.beef,mode=gui,mediatype=song,dbid=$INFO[ListItem.DBID])</onclick>
+                        <onclick condition="Container.Content(musicvideos)">RunScript(script.artwork.beef,mode=gui,mediatype=musicvideo,dbid=$INFO[ListItem.DBID])</onclick>
                     </item>
                 </content>
             </control>

--- a/xml/DialogMusicInfo.xml
+++ b/xml/DialogMusicInfo.xml
@@ -364,38 +364,20 @@
                             <visible>!String.IsEmpty(Window.Property(AdditionalMusicInfo))</visible>
                         </control>
 
-                        <!-- Artwork Beef -->
+                        <!-- Artwork -->
                         <control type="button" id="101">
-                            <!--Get Thumb Artwork Beef-->
+                            <!--If AB is installed open Custom_MediaDialog, otherwise use build in Dialog-->
                             <label>13511</label>
                             <width>285</width>
                             <height>60</height>
                             <align>center</align>
                             <textoffsetx>0</textoffsetx>
                             <description>Get Artwork</description>
-                            <onclick condition="String.IsEqual(ListItem.DBType,music) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=music, dbid=$INFO[ListItem.DBID])</onclick>
-                            <onclick condition="String.IsEqual(ListItem.DBType,song) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
-                            <onclick condition="String.IsEqual(ListItem.DBType,album) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
-                            <onclick condition="String.IsEqual(ListItem.DBType,artist) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
-                            <onclick condition="!System.HasAddon(script.artwork.beef)">RunPlugin(plugin://script.artwork.beef)</onclick>
-                            <visible>[String.IsEqual(ListItem.DBType,music) | String.IsEqual(ListItem.DBType,song) | String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,artist)] + System.HasAddon(script.artwork.beef)</visible>
+                            <onclick condition="System.HasAddon(script.artwork.beef)">ActivateWindow(3004)</onclick>
+                            <onclick condition="!System.HasAddon(script.artwork.beef)">SendClick(2003,10)</onclick>
                             <visible>!Skin.HasSetting(KioskMode.Enabled)</visible>
                             <visible>Skin.HasSetting(musicinfo_button_artwork)</visible>
                         </control>
-
-                        <!--	Preparation to restore old artwork dialog but with artwork beef
-                            <control type="button" id="101">
-                                &lt;!&ndash;Artwork&ndash;&gt;
-                                <label>13405</label>
-                                <width>285</width>
-                                <height>60</height>
-                                <align>center</align>
-                                <textoffsetx>0</textoffsetx>
-                                <visible>Skin.HasSetting(videoinfo_button_artwork)</visible>
-                                <onclick condition="System.HasAddon(script.artwork.beef)">ActivateWindow(3004)</onclick>
-                                <onclick condition="!System.HasAddon(script.artwork.beef)">RunPlugin(plugin://script.artwork.beef)</onclick>
-                                <visible>!Skin.HasSetting(KioskMode.Enabled)</visible>
-                            </control>-->
 
                         <control type="button" id="7">
                             <!--set personal rating-->

--- a/xml/DialogMusicInfo.xml
+++ b/xml/DialogMusicInfo.xml
@@ -374,7 +374,7 @@
                             <textoffsetx>0</textoffsetx>
                             <description>Get Artwork</description>
                             <onclick condition="System.HasAddon(script.artwork.beef)">ActivateWindow(3004)</onclick>
-                            <onclick condition="!System.HasAddon(script.artwork.beef)">SendClick(2003,10)</onclick>
+                            <onclick condition="!System.HasAddon(script.artwork.beef)">SendClick(12001,10)</onclick>
                             <visible>!Skin.HasSetting(KioskMode.Enabled)</visible>
                             <visible>Skin.HasSetting(musicinfo_button_artwork)</visible>
                         </control>

--- a/xml/DialogVideoInfo.xml
+++ b/xml/DialogVideoInfo.xml
@@ -366,21 +366,18 @@
 							<visible>System.HasAddon(script.tvtunes) + [String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + String.IsEmpty(Window(movieinformation).Property(TvTunes_HideVideoInfoButton))</visible>
 							<visible>false</visible>
 						</control>
-						
-						<!-- Artwork Beef -->
+
+						<!-- Artwork -->
 						<control type="button" id="104">
-							<!--Get Thumb Artwork Beef-->
+							<!--If AB is installed open Custom_MediaDialog, otherwise use build in Dialog-->
 							<label>13511</label>
 							<width>285</width>
 							<height>60</height>
 							<align>center</align>
 							<textoffsetx>0</textoffsetx>
-							<onclick condition="String.IsEqual(ListItem.DBType,episode) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=episode, dbid=$INFO[ListItem.DBID])</onclick>
-							<onclick condition="String.IsEqual(ListItem.DBType,tvshow) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
-							<onclick condition="String.IsEqual(ListItem.DBType,movie) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
-							<onclick condition="!System.HasAddon(script.artwork.beef)">RunPlugin(plugin://script.artwork.beef)</onclick>
 							<description>Get Artwork</description>
-							<visible>[String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,musicvideo) | String.IsEqual(ListItem.DBType,episode)] + System.HasAddon(script.artwork.beef)</visible>
+							<onclick condition="System.HasAddon(script.artwork.beef)">ActivateWindow(3004)</onclick>
+							<onclick condition="!System.HasAddon(script.artwork.beef)">SendClick(12003,10)</onclick>
 							<visible>!Skin.HasSetting(KioskMode.Enabled)</visible>
 							<visible>Skin.HasSetting(videoinfo_button_artwork)</visible>
 						</control>


### PR DESCRIPTION
Re-Enabled Custom Media Dialog:
Made Artwork Beef Dependency optional: If AB is available, Custom Media Dialog will open.
If it is missing, only internal Artwork Dialog will be used.
Made the whole Media Dialog hopefully a bit more semantically meaningful.
Works for TVshows, Movies and Musicvideos.
Removed more Artwork Downloader Strings